### PR TITLE
Add PHP enrollment CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # codex
+
+このリポジトリには、PHPで動作する簡単な在籍管理CLIアプリ `enrollment.php` が含まれています。
+
+## 使い方
+
+1. PHP がインストールされた環境で以下のコマンドを実行します。
+
+```
+# 在籍一覧を表示
+php enrollment.php list
+
+# 学生を追加
+php enrollment.php add 001 "山田 太郎"
+
+# 学生を削除
+php enrollment.php remove 001
+```
+
+2. 学生データは `students.json` に保存されます。

--- a/enrollment.php
+++ b/enrollment.php
@@ -1,0 +1,53 @@
+<?php
+// Simple enrollment management CLI script
+
+$dataFile = __DIR__ . '/students.json';
+$students = [];
+
+if (file_exists($dataFile)) {
+    $json = file_get_contents($dataFile);
+    $students = json_decode($json, true) ?: [];
+}
+
+$action = $argv[1] ?? null;
+
+switch ($action) {
+    case 'list':
+        if (empty($students)) {
+            echo "No students found\n";
+        } else {
+            foreach ($students as $id => $name) {
+                echo "$id: $name\n";
+            }
+        }
+        break;
+    case 'add':
+        $id = $argv[2] ?? null;
+        $name = $argv[3] ?? null;
+        if (!$id || !$name) {
+            echo "Usage: php enrollment.php add <id> <name>\n";
+            exit(1);
+        }
+        $students[$id] = $name;
+        file_put_contents($dataFile, json_encode($students, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        echo "Added student $id: $name\n";
+        break;
+    case 'remove':
+        $id = $argv[2] ?? null;
+        if (!$id) {
+            echo "Usage: php enrollment.php remove <id>\n";
+            exit(1);
+        }
+        if (!isset($students[$id])) {
+            echo "Student not found\n";
+            exit(1);
+        }
+        unset($students[$id]);
+        file_put_contents($dataFile, json_encode($students, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        echo "Removed student $id\n";
+        break;
+    default:
+        echo "Usage: php enrollment.php [list|add|remove] ...\n";
+        exit(0);
+}
+?>


### PR DESCRIPTION
## Summary
- add a simple PHP command-line tool `enrollment.php`
- document how to use the script in README

## Testing
- `php -l enrollment.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdf3b16988322a2c37128d096cc3c